### PR TITLE
Add data-maxwidth attribute

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -31,6 +31,9 @@
 		.mod-foo[data-minwidth~="500"] {
 		  background: gray;
 		}
+		.mod-foo[data-maxwidth~="499"] {
+		  font-weight: bold;
+		}
 
 		/* demo styles for the layout surrounding the element query element */
 		body {
@@ -83,6 +86,13 @@
 }
 </code></pre>
 	</li>
+	<li>The script will also maintain a <code>data-maxwidth</code> attribute on the elements which works from the same breakpoints, so you can write selectors to target the element when it's <em>narrower</em> than your chosen breakpoint, e.g.:
+<pre><code>
+.mod[data-maxwidth~="449"] {
+  font-weight: bold;
+}
+</code></pre>
+	</li>
 	</ol>
 
 	<p>That’s about it. Here’s the CSS for the sample element on this page:</p>
@@ -103,6 +113,9 @@
 }
 .mod-foo[data-minwidth~="500"] {
   background: gray;
+}
+.mod-foo[data-maxwidth~="499"] {
+  font-weight: bold;
 }
 </code></pre>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -31,7 +31,7 @@
 		.mod-foo[data-minwidth~="500"] {
 		  background: gray;
 		}
-		.mod-foo[data-maxwidth~="499"] {
+		.mod-foo[data-minwidth~="300"][data-maxwidth~="499"] {
 		  font-weight: bold;
 		}
 
@@ -92,6 +92,12 @@
   font-weight: bold;
 }
 </code></pre>
+These are less useful on their own, especially if you're working mobile first anyway, but when combined with min-width queries they can give you a level of precision closer to that of native media queries, e.g.:
+<pre><code>
+.mod[data-minwidth~="300"][data-maxwidth~="449"] {
+  font-weight: bold;
+}
+</code></pre>
 	</li>
 	</ol>
 
@@ -114,7 +120,7 @@
 .mod-foo[data-minwidth~="500"] {
   background: gray;
 }
-.mod-foo[data-maxwidth~="499"] {
+.mod-foo[data-minwidth~="300"][data-maxwidth~="499"] {
   font-weight: bold;
 }
 </code></pre>

--- a/src/elementary.js
+++ b/src/elementary.js
@@ -12,14 +12,19 @@
 				breakpoints = w.getComputedStyle( mod, ":before" ).getPropertyValue( "content" ),
 				widths = breakpoints.replace(/[^\d ]/g,"").split( " "),
 				modWidth = mod.clientWidth,
-				minWidths = [];
+				minWidths = [],
+				maxWidths = [];
 
 			for( var i = 0; i < widths.length; i++ ){
 				if( w.parseFloat( widths[ i ] ) <= modWidth ){
 					minWidths.push( widths[ i ] );
 				}
+				else {
+					maxWidths.push( w.parseInt( widths[ i ] ) - 1 );
+				}
 			}
 			mod.setAttribute( "data-minwidth", minWidths.join( " " ) );
+			mod.setAttribute( "data-maxwidth", maxWidths.join( " " ) );
 		}
 	};
 


### PR DESCRIPTION
Updated the script to add a `data-maxwidth` attribute (off the back of the same calculation), so you can target the element when it's _narrower_ than the breakpoint, so you can do the equivilant of `@media (min-width:300px) and (max-width:449px) {}`.
